### PR TITLE
update to 1.26.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,2 @@
-aggregate_check: false
-upload_channels:
-  - sfe1ed40
-  - services
 channels:
-  - sfe1ed40
-  - services
+  - https://staging.continuum.io/prefect/fs/opentelemetry-exporter-otlp-proto-common-feedstock/pr4/299c469

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/opentelemetry-exporter-otlp-proto-common-feedstock/pr4/299c469

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,36 +1,34 @@
 {% set name = "opentelemetry-exporter-otlp-proto-grpc" %}
-{% set version = "1.12.0" %}
-{% set sha256 = "b69a5b080cabcb4e69e5fb27f697def3fb59685b11360fa2db01bea827b9cc97" %}
+{% set version = "1.26.0" %}
+{% set sha256 = "a65b67a9a6b06ba1ec406114568e21afe88c1cdb29c464f2507d529eb906d8ae" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry-exporter-otlp-proto-grpc-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_exporter_otlp_proto_grpc-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
   number: 0
-  # noarch: python
-  skip: true  # [py<36]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
     - pip
     - python
-    - setuptools
-    - wheel
+    - hatchling
   run:
     - python
-    - grpcio <2.0.0,>=1.0.0
-    - googleapis-common-protos >=1.52,<2
-    - opentelemetry-api >=1.3,<2
-    - opentelemetry-sdk >=1.11,<2
-    - opentelemetry-proto ==1.12.0
-    - backoff >=1.10.0,<2  # [py<37]
-    - backoff >=1.10.0,<3  # [py>=37]
+    - deprecated >=1.2.6
+    - googleapis-common-protos >=1.52,<2.dev0
+    - grpcio >=1.0.0,<2.0.0
+    - opentelemetry-api >=1.15,<2.dev0
+    - opentelemetry-proto ==1.26.0
+    - opentelemetry-sdk >=1.26.0,<1.27.dev0
+    - opentelemetry-exporter-otlp-proto-common ==1.26.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,8 +45,8 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  doc_url: https://opentelemetry-python.readthedocs.io/en/latest/
-  doc_source_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs
+  doc_url: https://opentelemetry-python.readthedocs.io
+  dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-grpc
   description: |-
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
     Observability framework for instrumenting, generating, collecting, and exporting


### PR DESCRIPTION
opentelemetry-exporter-otlp-proto-grpc 1.26.0

**Destination channel:** main

### Links

- PKG-6322
- https://github.com/open-telemetry/opentelemetry-python/tree/v1.26.0/exporter/opentelemetry-exporter-otlp-proto-grpc
