### PR TITLE
opentelemetry-exporter-otlp-proto-grpc 1.37.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,10 @@ requirements:
     - opentelemetry-exporter-otlp-proto-common =={{ version }}
     - typing-extensions >=4.6.0
 
+# E   ModuleNotFoundError: No module named 'opentelemetry.test'
+# https://pypi.org/project/opentelemetry-test-utils, not in the main channel.
+{% set ignore_tests = " --ignore=tests/test_otlp_metrics_exporter.py" %}
+{% set ignore_tests = ignore_tests + " --ignore=tests/test_otlp_trace_exporter.py" %}
 test:
   source_files:
     - tests
@@ -37,7 +41,7 @@ test:
     - opentelemetry.exporter.otlp.proto.grpc
   commands:
     - pip check
-    - pytest -v tests
+    - pytest -v tests {{ ignore_tests }}
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,18 @@
 {% set name = "opentelemetry-exporter-otlp-proto-grpc" %}
-{% set version = "1.30.0" %}
+{% set version = "1.37.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_exporter_otlp_proto_grpc-{{ version }}.tar.gz
-  sha256: d0f10f0b9b9a383b7d04a144d01cb280e70362cccc613987e234183fd1f01177
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
+  sha256: f55bcb9fc848ce05ad3dd954058bc7b126624d22c4d9e958da24d8537763bec5
 
 build:
   number: 0
-  skip: true  # [py<38]
-  skip: true  # [s390x]   
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<39]
 
 requirements:
   host:
@@ -22,22 +21,26 @@ requirements:
     - hatchling
   run:
     - python
-    - deprecated >=1.2.6
-    - googleapis-common-protos >=1.52,<2.0.0.dev0
-    - grpcio >=1.63.2,<2.0.0
-    - opentelemetry-api >=1.15,<2.0.0.dev0
-    - opentelemetry-proto ==1.30.0
-    - opentelemetry-sdk >=1.30.0,<1.31.0.dev0
-    - opentelemetry-exporter-otlp-proto-common ==1.30.0
+    - googleapis-common-protos >=1.57,<2
+    - grpcio >=1.63.2,<2.0.0  # [py<313]
+    - grpcio >=1.66.2  # [py>=313]
+    - opentelemetry-api >=1.15,<2
+    - opentelemetry-proto =={{ version }}
+    - opentelemetry-sdk >=1.37.0,<1.38
+    - opentelemetry-exporter-otlp-proto-common =={{ version }}
+    - typing-extensions >=4.6.0
 
 test:
+  source_files:
+    - tests
   imports:
-    - opentelemetry
-    - opentelemetry.exporter
+    - opentelemetry.exporter.otlp.proto.grpc
   commands:
     - pip check
+    - pytest -v tests
   requires:
     - pip
+    - pytest
 
 about:
   summary: OpenTelemetry Python / Protobuf over gRPC Exporter


### PR DESCRIPTION
opentelemetry-exporter-otlp-proto-grpc 1.37.0 

**Destination channel:** Defaults

### Links

- [PKG-9823]
- dev_url:        https://github.com/open-telemetry/opentelemetry-python/tree/v1.37.0
- conda_forge:    https://github.com/conda-forge/opentelemetry-exporter-otlp-proto-grpc-feedstock
- pypi:           https://pypi.org/project/opentelemetry-exporter-otlp-proto-grpc/1.37.0
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-exporter-otlp-proto-grpc/1.37.0

### Explanation of changes:

- new version number


[PKG-9823]: https://anaconda.atlassian.net/browse/PKG-9823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ