### PR TITLE
opentelemetry-exporter-otlp-proto-grpc 1.12.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,2 @@
-aggregate_check: false
 upload_channels:
   - sfe1ed40
-  - services
-channels:
-  - sfe1ed40
-  - services

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,36 +1,35 @@
 {% set name = "opentelemetry-exporter-otlp-proto-grpc" %}
 {% set version = "1.12.0" %}
-{% set sha256 = "b69a5b080cabcb4e69e5fb27f697def3fb59685b11360fa2db01bea827b9cc97" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry-exporter-otlp-proto-grpc-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: b69a5b080cabcb4e69e5fb27f697def3fb59685b11360fa2db01bea827b9cc97
 
 build:
-  number: 0
-  # noarch: python
+  number: 4
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: true  # [py<36]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
     - pip
     - python
-    - setuptools
+    - setuptools <81
     - wheel
   run:
     - python
-    - grpcio <2.0.0,>=1.0.0
+    - grpcio >=1.0.0,<2.0.0
     - googleapis-common-protos >=1.52,<2
     - opentelemetry-api >=1.3,<2
     - opentelemetry-sdk >=1.11,<2
     - opentelemetry-proto ==1.12.0
     - backoff >=1.10.0,<2  # [py<37]
     - backoff >=1.10.0,<3  # [py>=37]
+    - setuptools <81
 
 test:
   imports:
@@ -47,13 +46,13 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  doc_url: https://opentelemetry-python.readthedocs.io/en/latest/
-  doc_source_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs
-  description: |-
+  description: |
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
     Observability framework for instrumenting, generating, collecting, and exporting
     telemetry data such as traces, metrics, logs. As an industry-standard
     it is natively supported by a number of vendors.
+  doc_url: https://opentelemetry-python.readthedocs.io
+  dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-grpc
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 build:
   number: 4
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: true  # [py<36]
+  # protobuf<6 and abseil<20250127.1.0a0 conflicts with py314
+  skip: true  # [py<36 or py>=314]
 
 requirements:
   host:


### PR DESCRIPTION
opentelemetry-exporter-otlp-proto-grpc 1.12.0

**Destination channel:** Snowflake

### Links

- [PKG-14903](https://anaconda.atlassian.net/browse/PKG-14903) 
- [Upstream repository](https://inspector.pypi.io/project/opentelemetry-exporter-otlp-proto-grpc/1.12.0/)

### Explanation of changes:

- rebuild


[PKG-14903]: https://anaconda.atlassian.net/browse/PKG-14903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ